### PR TITLE
Spring: use proper JSP dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,11 @@ dependencies {
 
     implementation 'org.postgresql:postgresql:42.3.3'
     compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
-    implementation 'javax.servlet.jsp.jstl:jstl-api:1.2'
+    implementation 'javax.servlet:jstl'
     implementation 'org.springframework:spring-jdbc:5.3.18'
-    implementation 'org.springframework:spring-webmvc:5.3.17'
+    implementation 'org.springframework:spring-webmvc:5.3.18'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework:spring-context-support:5.3.16'
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 
     // Test


### PR DESCRIPTION
This makes the app work when I run `./gradlew bootWar`, then go to `localhost:8080/showStudent`.